### PR TITLE
updated readme with required packages on Debian 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ How to build the system manualy:
 
 The system requires Ubuntu 18 or Debian 9!
 
+Required packages (Debian 9)
+
+```
+apt-get install whois dirmngr multistrap reprepro binutils squashfs-tools
+```
+
 clone the repository, go to SbcOS and run:
 
 ```


### PR DESCRIPTION
I needed to install also dirmngr binutils squashfs-tools on a fresh debian 9. For convenience I've added the apt-get command to the readme. 